### PR TITLE
Catch retrieveToken errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18737,6 +18737,7 @@ const core = __nccwpck_require__(2186);
 const rsasign = __nccwpck_require__(7175);
 const fs = __nccwpck_require__(7147);
 const { default: got } = __nccwpck_require__(3061);
+const { error } = __nccwpck_require__(6206);
 
 const defaultKubernetesTokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 /***
@@ -18772,7 +18773,9 @@ async function retrieveToken(method, client) {
                     core.debug("Fetching ID token from GitHub OIDC provider")
                     jwt = await core.getIDToken(githubAudience)
                 } catch (err) {
-                    throw Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`)
+                    const new_error = new Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`);
+                    new_error.stack += err.stack;
+                    throw new_error;
                 }
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
@@ -18831,7 +18834,9 @@ function generateJwt(privateKey, keyPassword, ttl) {
         const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
         return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
     } catch (err) {
-        throw Error(`Unable to generate Jwt. message: ${err?.message}`)
+        const new_error = new Error(`Error generating the jwt., message: ${err?.message}`);
+        new_error.stack += err.stack;
+        throw new_error;
     }
 }
 
@@ -19021,6 +19026,14 @@ module.exports = require("assert");
 
 "use strict";
 module.exports = require("buffer");
+
+/***/ }),
+
+/***/ 6206:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("console");
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18772,9 +18772,7 @@ async function retrieveToken(method, client) {
                     core.debug("Fetching ID token from GitHub OIDC provider")
                     jwt = await core.getIDToken(githubAudience)
                 } catch (err) {
-                    core.error("Error fetching ID token from GitHub OIDC provider")
-                    core.setOutput(err?.message)
-                    throw err
+                    throw Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`)
                 }
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
@@ -18833,8 +18831,7 @@ function generateJwt(privateKey, keyPassword, ttl) {
         const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
         return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
     } catch (err) {
-        core.setOutput(err?.message)
-        throw Error("Unable to generate Jwt")
+        throw Error(`Unable to generate Jwt. message: ${err?.message}`)
     }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18830,14 +18830,8 @@ function generateJwt(privateKey, keyPassword, ttl) {
         repository: process.env.GITHUB_REPOSITORY,
         ref: process.env.GITHUB_REF
     };
-    try{
-        const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
-        return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
-    } catch (err) {
-        const new_error = new Error(`Error generating the jwt., message: ${err?.message}`);
-        new_error.stack += err.stack;
-        throw new_error;
-    }
+    const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
+    return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
 }
 
 /***

--- a/src/auth.js
+++ b/src/auth.js
@@ -38,9 +38,7 @@ async function retrieveToken(method, client) {
                     core.debug("Fetching ID token from GitHub OIDC provider")
                     jwt = await core.getIDToken(githubAudience)
                 } catch (err) {
-                    core.error("Error fetching ID token from GitHub OIDC provider")
-                    core.setOutput(err?.message)
-                    throw err
+                    throw Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`)
                 }
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
@@ -99,8 +97,7 @@ function generateJwt(privateKey, keyPassword, ttl) {
         const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
         return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
     } catch (err) {
-        core.setOutput(err?.message)
-        throw Error("Unable to generate Jwt")
+        throw Error(`Unable to generate Jwt. message: ${err?.message}`)
     }
 }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -96,14 +96,8 @@ function generateJwt(privateKey, keyPassword, ttl) {
         repository: process.env.GITHUB_REPOSITORY,
         ref: process.env.GITHUB_REF
     };
-    try{
-        const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
-        return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
-    } catch (err) {
-        const new_error = new Error(`Error generating the jwt., message: ${err?.message}`);
-        new_error.stack += err.stack;
-        throw new_error;
-    }
+    const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
+    return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
 }
 
 /***

--- a/src/auth.js
+++ b/src/auth.js
@@ -3,6 +3,7 @@ const core = require('@actions/core');
 const rsasign = require('jsrsasign');
 const fs = require('fs');
 const { default: got } = require('got');
+const { error } = require('console');
 
 const defaultKubernetesTokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 /***
@@ -38,7 +39,9 @@ async function retrieveToken(method, client) {
                     core.debug("Fetching ID token from GitHub OIDC provider")
                     jwt = await core.getIDToken(githubAudience)
                 } catch (err) {
-                    throw Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`)
+                    const new_error = new Error(`Error fetching ID token from GitHub OIDC provider., message: ${err.message}`);
+                    new_error.stack += err.stack;
+                    throw new_error;
                 }
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
@@ -97,7 +100,9 @@ function generateJwt(privateKey, keyPassword, ttl) {
         const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
         return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
     } catch (err) {
-        throw Error(`Unable to generate Jwt. message: ${err?.message}`)
+        const new_error = new Error(`Error generating the jwt., message: ${err?.message}`);
+        new_error.stack += err.stack;
+        throw new_error;
     }
 }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -34,7 +34,14 @@ async function retrieveToken(method, client) {
             const githubAudience = core.getInput('jwtGithubAudience', { required: false });
 
             if (!privateKey) {
-                jwt = await core.getIDToken(githubAudience)
+                try {
+                    core.debug("Fetching ID token from GitHub OIDC provider")
+                    jwt = await core.getIDToken(githubAudience)
+                } catch (err) {
+                    core.error("Error fetching ID token from GitHub OIDC provider")
+                    core.setOutput(err?.message)
+                    throw err
+                }
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
             }
@@ -88,8 +95,13 @@ function generateJwt(privateKey, keyPassword, ttl) {
         repository: process.env.GITHUB_REPOSITORY,
         ref: process.env.GITHUB_REF
     };
-    const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
-    return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
+    try{
+        const decryptedKey = rsasign.KEYUTIL.getKey(privateKey, keyPassword);
+        return rsasign.KJUR.jws.JWS.sign(alg, JSON.stringify(header), JSON.stringify(payload), decryptedKey);
+    } catch (err) {
+        core.setOutput(err?.message)
+        throw Error("Unable to generate Jwt")
+    }
 }
 
 /***

--- a/src/auth.test.js
+++ b/src/auth.test.js
@@ -13,7 +13,6 @@ const got = require('got');
 const fs = require("fs")
 const { when } = require('jest-when');
 
-
 const {
     retrieveToken
 } = require('./auth');
@@ -84,5 +83,24 @@ describe("test retrival for token", () => {
         expect(payload).toEqual({ jwt: jwtToken, role: testRole })
         const url = got.post.mock.calls[0][0]
         expect(url).toContain('differentK8sPath')
+    })
+
+    it("test JWT with GitHub OIDC Tokens", async () => {
+        const method = 'jwt'
+        const jwtToken = "someJwtToken"
+        const testRole = "testRole"
+        const testGitHubAudience = "testGitHubAudience"
+        mockApiResponse()
+        mockInput("role", testRole)
+        mockInput("jwtGithubAudience", testGitHubAudience)
+        mockInput("jwtPrivateKey", "")
+        mockInput()
+        core.getIDToken = jest.fn().mockReturnValueOnce(jwtToken)
+        const token = await retrieveToken(method, got)
+        expect(token).toEqual(testToken)
+        const payload = got.post.mock.calls[0][1].json
+        expect(payload).toEqual({ jwt: jwtToken, role: testRole })
+        const url = got.post.mock.calls[0][0]
+        expect(url).toContain('jwt')
     })
 })


### PR DESCRIPTION
## Description

This adds a try-catch to `await core.getIDToken(githubAudience)` and to the part of `generateJwt(privateKey, keyPassword, Number(tokenTtl));` that makes an external service call. 

We actually just use `core.getIDToken`, but I figured I might as well as another try-catch.

`core.getIDToken` actually does up to 10 retries automatically ([here](https://github.com/actions/toolkit/blob/63c648f3c20feb23a4251afd9b3574570d38748a/packages/core/src/oidc-utils.ts#L11-L19)), so we don't need to add retries here. But I'm hoping a try-catch here will reduce the `triggerUncaughtException(err, true /* fromPromise */)` errors and help us debug.

I also added a test for authenticating using `jwt` and GitHub OIDC.

## Testing
Using https://github.com/github/internal-actions/pull/332 to test

cc\ https://github.com/github/build-systems/issues/3307